### PR TITLE
add - modify diary data

### DIFF
--- a/app/src/main/java/kr/co/gachon/emotion_diary/MainActivity.java
+++ b/app/src/main/java/kr/co/gachon/emotion_diary/MainActivity.java
@@ -4,9 +4,7 @@ package kr.co.gachon.emotion_diary;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
-import android.widget.ImageButton;
 
-import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -16,6 +14,7 @@ import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
 
 import java.util.Calendar;
+import java.util.Date;
 
 import kr.co.gachon.emotion_diary.data.Diary;
 import kr.co.gachon.emotion_diary.data.DiaryRepository;
@@ -56,10 +55,27 @@ public class MainActivity extends AppCompatActivity {
         FloatingActionButton diaryWriteButton = findViewById(R.id.diary_write_button);
 
         diaryWriteButton.setOnClickListener(v -> {
-            Intent intent = new Intent(getApplicationContext(), DiaryWriteActivity.class);
-            intent.putExtra("selectedDate", System.currentTimeMillis());
-            startActivity(intent);
+            Calendar calendar = Calendar.getInstance();
+            Date todayDate = calendar.getTime();
+
+            diaryRepository.getDiaryByDate(todayDate, diary -> {
+                Intent intent = new Intent(getApplicationContext(), DiaryWriteActivity.class);
+                intent.putExtra("selectedDate", System.currentTimeMillis());
+
+                if (diary != null) {
+                    // 같은 연, 월, 일에 해당하는 값을 가져오는 logic
+                    intent.putExtra("title", diary.getTitle());
+                    intent.putExtra("content", diary.getContent());
+                    intent.putExtra("isUpdate", true);
+                } else {
+                    // 그 외 상황이면 작성하는 logic
+                    intent.putExtra("isUpdate", false);
+                }
+
+                startActivity(intent);
+            });
         });
+
 
         // --------- DB TEST START ---------
         diaryRepository = new DiaryRepository(getApplication());

--- a/app/src/main/java/kr/co/gachon/emotion_diary/data/DiaryDao.java
+++ b/app/src/main/java/kr/co/gachon/emotion_diary/data/DiaryDao.java
@@ -30,6 +30,10 @@ public interface DiaryDao {
     @Query("SELECT COUNT(DISTINCT strftime('%Y-%m-%d', date / 1000, 'unixepoch')) FROM diaries WHERE date BETWEEN :startDate AND :endDate")
     int getDiaryCountPerDay(Date startDate, Date endDate);
 
+    // DiaryDao날짜 기준 검색 쿼리 추가
+    @Query("SELECT * FROM diaries WHERE strftime('%Y-%m-%d', date / 1000, 'unixepoch') = :date ORDER BY id DESC LIMIT 1")
+    Diary getLatestDiaryByDate(String date);
+
     @Query("SELECT * FROM diaries WHERE date BETWEEN :startDate AND :endDate ORDER BY date ASC")
     LiveData<List<Diary>> getDiariesForDateRange(Date startDate, Date endDate);
 

--- a/app/src/main/java/kr/co/gachon/emotion_diary/data/DiaryRepository.java
+++ b/app/src/main/java/kr/co/gachon/emotion_diary/data/DiaryRepository.java
@@ -1,6 +1,8 @@
 package kr.co.gachon.emotion_diary.data;
 
 import android.app.Application;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 
 import androidx.lifecycle.LiveData;
@@ -8,12 +10,14 @@ import androidx.lifecycle.Transformations;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Consumer;
 
 public class DiaryRepository {
 
@@ -77,6 +81,22 @@ public class DiaryRepository {
 
     public void delete(Diary diary) {
         executorService.execute(() -> diaryDao.deleteDiary(diary));
+    }
+
+    // 같은 연도, 월, 일에 해당하는 최근정보를 불러오는 logic
+    public void getDiaryByDate(Date date, Consumer<Diary> callback) {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
+        String formattedDate = sdf.format(date);
+        getLatestDiaryByDateAsync(formattedDate, callback);
+    }
+
+    public void getLatestDiaryByDateAsync(String date, Consumer<Diary> callback) {
+        executorService.execute(() -> {
+            Diary diary = diaryDao.getLatestDiaryByDate(date);
+            new Handler(Looper.getMainLooper()).post(() -> {
+                callback.accept(diary);
+            });
+        });
     }
 
     public void insertDummyData() {


### PR DESCRIPTION
## 🔗 관련 이슈

연관된 이슈 번호를 적어주세요. (예: #123)
#79
---

## 📌 PR 요약

diarywritebutton을 눌렀을 때 이미 현재 연, 월, 일에 해당하는 title과 content가 입력이 되어 있으면 불러와서 수정하기 효과를 주었습니다.
그 외 상황이면 작성하기로 사용됩니다.

---

## 📑 작업 내용

작업의 세부 내용을 작성해주세요.
1. diaryrepository에서 최근 정보를 가져오기 위해 diarydao에 있는 getLatestDiaryByDate라는 quary를 호출했습니다. 
2. mainactivity에서 diarywritebutton을 눌렀을 때 수정할지 작성할지에 대한 logic을 거쳐갑니다.
3.  그 후 diarywriteactivity에 해당 연 월 일에 해당하는 title과 content값을 미리 set하여 채워눠서 수정과 같은 효과를 주었습니다.
4. 스크린샷 달력보면 이미 데이터가 삽입되어 있고 슬픔표시로 되어 있으니 작성이 되어 있다는걸 뜻합니다. 해당 연 월 일에 해당하는 title과 content값을 set하여 수정하기로 넘어간 것으로 보입니다. 
---

## 스크린샷 (선택)
<img width="313" alt="image" src="https://github.com/user-attachments/assets/2b77a59a-95d9-4163-9907-ddf17ecae2c1" />

<img width="299" alt="image" src="https://github.com/user-attachments/assets/e3a13c70-3541-4ef4-9b06-3ecfddd2317e" />


---

## 💡 추가 참고 사항

수정하기 일 경우 button image를 뭐로 바꿀지 의논해야 합니다.
