### PR TITLE
Feature/#119 disable android default logo

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -38,6 +38,7 @@
     </style>
 
     <style name="SplashTheme" parent="Theme.EmotionDiary">
+        <item name="android:windowIsTranslucent">true</item>
         <item name="windowNoTitle">true</item>
         <item name="windowActionBar">false</item>
     </style>


### PR DESCRIPTION
## 🔗 관련 이슈


---

## 📌 PR 요약

안드로이드 기본 로고 비활성화

---

## 📑 작업 내용

안드로이드 기본 로고 투명으로 설정 -> 안보이게 설정 

---

## 스크린샷 (선택)


---

## 💡 추가 참고 사항

PR에 대해 추가적으로 논의하거나 참고해야 할 내용을 작성해주세요.
(예: 변경사항이 코드베이스에 미치는 영향, 테스트 방법 등)
