### PR TITLE
fix - change diary write UI

### DIFF
--- a/app/src/main/res/layout/activity_diary_write.xml
+++ b/app/src/main/res/layout/activity_diary_write.xml
@@ -39,7 +39,8 @@
             app:boxCornerRadiusTopStart="12dp"
             app:boxCornerRadiusTopEnd="12dp"
             app:boxCornerRadiusBottomStart="12dp"
-            app:boxCornerRadiusBottomEnd="12dp">
+            app:boxCornerRadiusBottomEnd="12dp"
+            app:hintTextColor="@color/colorOnBackground">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/titleTextView"
@@ -63,7 +64,8 @@
             app:boxCornerRadiusTopStart="12dp"
             app:boxCornerRadiusTopEnd="12dp"
             app:boxCornerRadiusBottomStart="12dp"
-            app:boxCornerRadiusBottomEnd="12dp">
+            app:boxCornerRadiusBottomEnd="12dp"
+            app:hintTextColor="@color/colorOnBackground">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/contentTextView"


### PR DESCRIPTION
올라오는 글자에 색깔을 하얀색에서 변경했습니다

## 🔗 관련 이슈

연관된 이슈 번호를 적어주세요. (예: #123)
#165 
---

## 📌 PR 요약

diary write 부분에서 제목과 내용 적을 때 위쪽에 하얀색이 올라왔는데
하얀색 대신 다른 색깔이 올라오게 바꿨습니다

---

## 📑 작업 내용

작업의 세부 내용을 작성해주세요.
1. 작업 내용 1
2. 작업 내용 2
3. 작업 내용 3

---

## 스크린샷 (선택)


---

## 💡 추가 참고 사항

PR에 대해 추가적으로 논의하거나 참고해야 할 내용을 작성해주세요.
(예: 변경사항이 코드베이스에 미치는 영향, 테스트 방법 등)
